### PR TITLE
Support dots in bucket names

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var s3urls = module.exports = {
       key = uri.pathname.split('/').slice(2).join('/');
     }
     if (style === 'bucket-in-host') {
-      bucket = uri.hostname.split('.')[0];
+      bucket = uri.hostname.split('.').slice(0, -3).join('.');
       key = uri.pathname.slice(1);
     }
 


### PR DESCRIPTION
This lib was parsing urls like `https://www.mysite.com.s3.amazonaws.com/path` incorrectly, returning only `www` as the bucket name. Here is a fix.

This PR fixes (https://github.com/mapbox/mapbox-tile-copy/issues/53).
