### PR TITLE
Fix empty key being turned into 'ull'

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,7 @@ var parse = require('url').parse;
 var s3urls = module.exports = {
   fromUrl: function(url) {
     var uri = parse(url);
-
-    uri.pathname = decodeURIComponent(uri.pathname);
+    uri.pathname = decodeURIComponent(uri.pathname || '');
 
     var style = (function(uri) {
       if (uri.protocol === 's3:') return 's3';

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -23,6 +23,13 @@ test('fromUrl: s3 style', function(t) {
   t.end();
 });
 
+test('fromUrl: s3 bucket only style', function(t) {
+  var result = s3Urls.fromUrl('s3://bucket');
+  t.equal(result.Bucket, 'bucket', 'expected bucket');
+  t.equal(result.Key, null, 'expected key');
+  t.end();
+});
+
 test('fromUrl: bucket-in-path style', function(t) {
   var result = s3Urls.fromUrl('https://s3.amazonaws.com/bucket/the/whole/key');
   t.equal(result.Bucket, 'bucket', 'expected bucket');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -26,7 +26,14 @@ test('fromUrl: s3 style', function(t) {
 test('fromUrl: s3 bucket only style', function(t) {
   var result = s3Urls.fromUrl('s3://bucket');
   t.equal(result.Bucket, 'bucket', 'expected bucket');
-  t.equal(result.Key, null, 'expected key');
+  t.equal(result.Key, '', 'expected key');
+  t.end();
+});
+
+test('fromUrl: s3 bucket only style with slash', function(t) {
+  var result = s3Urls.fromUrl('s3://bucket/');
+  t.equal(result.Bucket, 'bucket', 'expected bucket');
+  t.equal(result.Key, '', 'expected key');
   t.end();
 });
 


### PR DESCRIPTION
`fromUrl('s3://bucket')` was returning `{Bucket: 'bucket', Key: 'ull'}` so I fixed it and added a regression test. `Key` is now an empty string (`''`) in this case.
