### PR TITLE
Make executable tests run cross-platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/mapbox/s3urls",
   "devDependencies": {
+    "cross-exec-file": "^1.0.0",
     "tape": "^3.0.3"
   },
   "dependencies": {

--- a/test/executable.test.js
+++ b/test/executable.test.js
@@ -1,10 +1,10 @@
 var test = require('tape').test;
-var exec = require('child_process').exec;
+var exec = require('cross-exec-file');
 var path = require('path');
 var cmd = path.resolve(__dirname, '..', 'bin', 's3urls.js');
 
 test('bad command', function(t) {
-  exec(cmd + ' ham', function(err, stdout, stderr) {
+  exec(cmd, ['ham'], function(err, stdout, stderr) {
     t.equal(err.code, 1, 'exit 1');
     t.equal(stderr, 'ERROR: Invalid command\n', 'expected message');
     t.end();
@@ -12,7 +12,7 @@ test('bad command', function(t) {
 });
 
 test('toUrl: bad args', function(t) {
-  exec(cmd + ' to-url', function(err, stdout, stderr) {
+  exec(cmd, ['to-url'], function(err, stdout, stderr) {
     t.equal(err.code, 1, 'exit 1');
     t.equal(stderr, 'ERROR: Must specify bucket and key\n', 'expected message');
     t.end();
@@ -26,7 +26,7 @@ test('toUrl: all types', function(t) {
     'https://bucket.s3.amazonaws.com/key'
   ];
 
-  exec(cmd + ' to-url bucket key', function(err, stdout, stderr) {
+  exec(cmd, ['to-url', 'bucket', 'key'], function(err, stdout, stderr) {
     t.ifError(err, 'completed');
     stdout.trim().split('\n').forEach(function(url) {
       t.ok(expected.indexOf(url) > -1, 'expected url');
@@ -38,7 +38,7 @@ test('toUrl: all types', function(t) {
 test('toUrl: s3 type', function(t) {
   expected = 's3://bucket/key';
 
-  exec(cmd + ' to-url bucket key --type s3', function(err, stdout, stderr) {
+  exec(cmd, ['to-url', 'bucket', 'key', '--type', 's3'], function(err, stdout, stderr) {
     t.ifError(err, 'completed');
     t.equal(stdout, expected + '\n', 'expected url');
     t.end();
@@ -48,7 +48,7 @@ test('toUrl: s3 type', function(t) {
 test('toUrl: bucket-in-path type', function(t) {
   expected = 'https://s3.amazonaws.com/bucket/key';
 
-  exec(cmd + ' to-url bucket key --type bucket-in-path', function(err, stdout, stderr) {
+  exec(cmd, ['to-url', 'bucket', 'key', '--type', 'bucket-in-path'], function(err, stdout, stderr) {
     t.ifError(err, 'completed');
     t.equal(stdout, expected + '\n', 'expected url');
     t.end();
@@ -58,7 +58,7 @@ test('toUrl: bucket-in-path type', function(t) {
 test('toUrl: bucket-in-host type', function(t) {
   expected = 'https://bucket.s3.amazonaws.com/key';
 
-  exec(cmd + ' to-url bucket key --type bucket-in-host', function(err, stdout, stderr) {
+  exec(cmd, ['to-url', 'bucket', 'key', '--type', 'bucket-in-host'], function(err, stdout, stderr) {
     t.ifError(err, 'completed');
     t.equal(stdout, expected + '\n', 'expected url');
     t.end();
@@ -66,7 +66,7 @@ test('toUrl: bucket-in-host type', function(t) {
 });
 
 test('fromUrl: no url', function(t) {
-  exec(cmd + ' from-url', function(err, stdout, stderr) {
+  exec(cmd, ['from-url'], function(err, stdout, stderr) {
     t.equal(err.code, 1, 'exit 1');
     t.equal(stderr, 'ERROR: No url given\n', 'expected message');
     t.end();
@@ -74,7 +74,7 @@ test('fromUrl: no url', function(t) {
 });
 
 test('fromUrl: unrecognized url', function(t) {
-  exec(cmd + ' from-url http://www.google.com', function(err, stdout, stderr) {
+  exec(cmd, ['from-url', 'http://www.google.com'], function(err, stdout, stderr) {
     t.equal(err.code, 1, 'exit 1');
     t.equal(stderr, 'ERROR: Unrecognizable S3 url\n', 'expected message');
     t.end();
@@ -82,7 +82,7 @@ test('fromUrl: unrecognized url', function(t) {
 });
 
 test('fromUrl: success', function(t) {
-  exec(cmd + ' from-url s3://bucket/key', function(err, stdout, stderr) {
+  exec(cmd, ['from-url', 's3://bucket/key'], function(err, stdout, stderr) {
     t.equal(stdout, JSON.stringify({
       Bucket: 'bucket',
       Key: 'key'
@@ -92,7 +92,7 @@ test('fromUrl: success', function(t) {
 });
 
 test('convert: no url', function(t) {
-  exec(cmd + ' convert', function(err, stdout, stderr) {
+  exec(cmd, ['convert'], function(err, stdout, stderr) {
     t.equal(err.code, 1, 'exit 1');
     t.equal(stderr, 'ERROR: No url given\n', 'expected message');
     t.end();
@@ -100,7 +100,7 @@ test('convert: no url', function(t) {
 });
 
 test('convert: unrecognized url', function(t) {
-  exec(cmd + ' convert http://www.google.com', function(err, stdout, stderr) {
+  exec(cmd, ['convert', 'http://www.google.com'], function(err, stdout, stderr) {
     t.equal(err.code, 1, 'exit 1');
     t.equal(stderr, 'ERROR: Unrecognizable S3 url\n', 'expected message');
     t.end();
@@ -108,14 +108,14 @@ test('convert: unrecognized url', function(t) {
 });
 
 test('convert: default success', function(t) {
-  exec(cmd + ' convert s3://bucket/key', function(err, stdout, stderr) {
+  exec(cmd, ['convert', 's3://bucket/key'], function(err, stdout, stderr) {
     t.equal(stdout, 'https://bucket.s3.amazonaws.com/key\n', 'expected result');
     t.end();
   });
 });
 
 test('convert: typed success', function(t) {
-  exec(cmd + ' convert s3://bucket/key --type bucket-in-path', function(err, stdout, stderr) {
+  exec(cmd, ['convert', 's3://bucket/key', '--type', 'bucket-in-path'], function(err, stdout, stderr) {
     t.equal(stdout, 'https://s3.amazonaws.com/bucket/key\n', 'expected result');
     t.end();
   });


### PR DESCRIPTION
Tests were failing on when the current path had spaces in it; also they depended on a Unix shell to interpret the shebang line at the top of `bin/s3urls.js`. Now they work.

I also took the liberty of adding a minimal `.gitignore` to help future contributors to this repo.
